### PR TITLE
Experiment with alternative fromList with different tradeoffs

### DIFF
--- a/benchmark/elm.json
+++ b/benchmark/elm.json
@@ -1,0 +1,30 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src",
+         "../src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/browser": "1.0.2",
+            "elm/core": "1.0.5",
+            "elm/html": "1.0.0",
+            "elm-explorations/benchmark": "1.0.1"
+        },
+        "indirect": {
+            "BrianHicks/elm-trend": "2.1.3",
+            "Skinney/murmur3": "2.0.8",
+            "elm/json": "1.1.3",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.2",
+            "mdgriffith/style-elements": "5.0.1"
+        }
+    },
+    "test-dependencies": {
+        "direct": {},
+        "indirect": {}
+    }
+}

--- a/benchmark/src/Main.elm
+++ b/benchmark/src/Main.elm
@@ -1,0 +1,92 @@
+module Main exposing (main)
+
+import Benchmark exposing (..)
+import Benchmark.Runner exposing (BenchmarkProgram)
+import Lazy.Tree as Tree exposing (Tree)
+
+
+main : BenchmarkProgram
+main =
+    -- Benchmark.Runner.program createOnly
+    Benchmark.Runner.program createAndExpand
+
+
+createAndExpand : Benchmark
+createAndExpand =
+    describe "Create and expand everything"
+        [ benchmark "fromList (10 elems)" <|
+            \_ ->
+                noodle10
+                    |> Tree.fromList (\p i -> Maybe.map .id p == i.parent)
+                    |> Tree.forceForest
+        , benchmark "fromListWithComparableIds (10 elems)" <|
+            \_ ->
+                noodle10
+                    |> Tree.fromListWithComparableIds .id .parent
+                    |> Tree.forceForest
+        , benchmark "fromList (100 elems)" <|
+            \_ ->
+                noodle100
+                    |> Tree.fromList (\p i -> Maybe.map .id p == i.parent)
+                    |> Tree.forceForest
+        , benchmark "fromListWithComparableIds (100 elems)" <|
+            \_ ->
+                noodle100
+                    |> Tree.fromListWithComparableIds .id .parent
+                    |> Tree.forceForest
+        ]
+
+
+createOnly : Benchmark
+createOnly =
+    describe "Create only"
+        [ benchmark "fromList (10)" <|
+            \_ ->
+                noodle10
+                    |> Tree.fromList (\p i -> Maybe.map .id p == i.parent)
+        , benchmark "fromListWithComparableIds (10)" <|
+            \_ ->
+                noodle10
+                    |> Tree.fromListWithComparableIds .id .parent
+        , benchmark "fromList (100)" <|
+            \_ ->
+                noodle100
+                    |> Tree.fromList (\p i -> Maybe.map .id p == i.parent)
+        , benchmark "fromListWithComparableIds (100)" <|
+            \_ ->
+                noodle100
+                    |> Tree.fromListWithComparableIds .id .parent
+        ]
+
+
+type alias Item =
+    { id : Int
+    , parent : Maybe Int
+    }
+
+
+{-| Tree that looks like "1 -> 2 -> 3 -> ... -> n"
+-}
+noodle : Int -> List Item
+noodle n =
+    List.range 1 n
+        |> List.map
+            (\i ->
+                { parent = Just i
+                , id = i + 1
+                }
+            )
+        |> (::)
+            { parent = Nothing
+            , id = 1
+            }
+
+
+noodle10 : List Item
+noodle10 =
+    noodle 10
+
+
+noodle100 : List Item
+noodle100 =
+    noodle 100


### PR DESCRIPTION
This is the initial rough sketch of my idea. Not sure if the improvement is worth it, but at least it confirms my hunch :smile: 

Testing with pathological trees like `1 -> 2 -> 3 -> ... -> 100` shows improved performance when expanding the whole tree
![Screenshot from 2020-07-16 07-27-08](https://user-images.githubusercontent.com/2716069/87631086-f0c7aa80-c736-11ea-9b23-fff642b72e1c.png)

But this comes at the cost of having to do the initial `n*log n` Dict construction (compared to basically O(1) complexity of fromList).
Maybe the initial dict construction could be "hidden" behind thunk as well to improve the performance in cases where user never expands the tree?
![Screenshot from 2020-07-16 07-30-58](https://user-images.githubusercontent.com/2716069/87631097-f8874f00-c736-11ea-9ce9-3286a90bd5c3.png)


